### PR TITLE
Fixing crash on Fragmen/Activity change

### DIFF
--- a/filter/src/main/java/com/yalantis/filter/widget/Filter.kt
+++ b/filter/src/main/java/com/yalantis/filter/widget/Filter.kt
@@ -346,7 +346,7 @@ class Filter<T : FilterModel> : FrameLayout, FilterItemListener, CollapseListene
         val superState = super.onSaveInstanceState()
         return Bundle().apply {
             putParcelable(STATE_SUPER, superState)
-            putBoolean(STATE_COLLAPSED, isCollapsed!!)
+            putBoolean(STATE_COLLAPSED, true)
             val selected = mSelectedItems
             val removed = mRemovedItems
             if (selected is Serializable) {


### PR DESCRIPTION
It fixes the null popinter exception when trying to change the current Fragment/Activty where the Filters are used.